### PR TITLE
MI imported map, grass path block is missing

### DIFF
--- a/datafiles/Data/Minecraft/1.18.midata
+++ b/datafiles/Data/Minecraft/1.18.midata
@@ -4032,6 +4032,11 @@
 		{
 			"name": "dirt_path",
 			"file": "dirt_path.json",
+			"id": "minecraft:grass_path"
+		},
+		{
+			"name": "dirt_path",
+			"file": "dirt_path.json",
 			"id": "minecraft:dirt_path"
 		},
 		{

--- a/scripts/buffer_read_string_short_be/buffer_read_string_short_be.gml
+++ b/scripts/buffer_read_string_short_be/buffer_read_string_short_be.gml
@@ -3,7 +3,10 @@
 
 var str = "";
 var str_length = buffer_read_short_be()
-// Read UTF-8 text
+if(str_length==0){
+	return str
+}
+// Read UTF-8 text  
 // Avoid buffer_Read (str_buffer, buffer_text) reading the terminator causes subsequent read errors.
 // Select to obtain the text range byte and then buffer_read.
 var str_buffer = buffer_create(str_length, buffer_fixed, 1);

--- a/scripts/buffer_read_string_short_be/buffer_read_string_short_be.gml
+++ b/scripts/buffer_read_string_short_be/buffer_read_string_short_be.gml
@@ -2,6 +2,15 @@
 /// @desc Reads a string consisting of a big endian short, then that many utf - 8 characters.
 
 var str = "";
-repeat (buffer_read_short_be())
-	str += chr(buffer_read_byte())
+var str_length = buffer_read_short_be()
+// Read UTF-8 text
+// Avoid buffer_Read (str_buffer, buffer_text) reading the terminator causes subsequent read errors.
+// Select to obtain the text range byte and then buffer_read.
+var str_buffer = buffer_create(str_length, buffer_fixed, 1);
+repeat (str_length){
+	buffer_write(str_buffer,buffer_u8, buffer_read_byte())
+}
+buffer_seek(str_buffer, buffer_seek_start, 0);
+str = buffer_read(str_buffer, buffer_text)
+buffer_delete(str_buffer)
 return str


### PR DESCRIPTION
MI imported 1.18.1 map with grass path square
But importing the map of 1.12.2, there is no grass path block. It seems that there are two types of grass path id, namely "minecraft:dirt_path" and "minecraft:grass_path"