### PR TITLE
Update CppGen Dependency (.NET 6 to .NET 9)

### DIFF
--- a/CppGen/CppGen/CppGen.csproj
+++ b/CppGen/CppGen/CppGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CppProject/World/Builder.cpp
+++ b/CppProject/World/Builder.cpp
@@ -593,7 +593,7 @@ namespace CppProject
 		QThread* thread;
 		QString outName = filename.QStr();
 		QString tempName = (QString)gmlGlobal::game_save_id + QFileInfo(filename).fileName();
-		thread = QThread::create([outName, tempName, data, &thread]
+		thread = QThread::create([outName, tempName, data]
 		{
 			Timer tmr;
 			QFile outFile(outName);

--- a/CppProject/World/Chunk.cpp
+++ b/CppProject/World/Chunk.cpp
@@ -29,10 +29,10 @@ namespace CppProject
 			NbtStream stream(data, {
 				{ TAG_BYTE, { "Y" } },
 				{ TAG_BYTE_ARRAY, { "SkyLight", "BlockLight", "Blocks", "Data", "Biomes", "Add" }},
-				{ TAG_COMPOUND, { "Level", "Properties", "block_states", "block_entities", "TileEntities", "biomes" }},
+				{ TAG_COMPOUND, { "Level", "properties", "Properties", "block_states", "block_entities", "TileEntities", "biomes" }},
 				{ TAG_LIST, { "sections", "Sections", "palette", "Palette" }},
 				{ TAG_LONG_ARRAY, { "data", "BlockStates"}},
-				{ TAG_STRING, { "Name", "Status" }},
+				{ TAG_STRING, { "Name", "id", "Status", "" }},
 				{ TAG_INT, { "DataVersion", "xPos", "zPos" }},
 			});
 			NbtCompound chunkCompound(stream);
@@ -42,7 +42,9 @@ namespace CppProject
 			if (chunkCompound.HasKey("DataVersion"))
 			{
 				IntType dataVersion = chunkCompound.Int("DataVersion");
-				if (dataVersion >= JAVA_1_18)
+				if (dataVersion >= JAVA_26_3)
+					format = JAVA_26_3; 
+				else if (dataVersion >= JAVA_1_18)
 					format = JAVA_1_18;
 				else if (dataVersion >= JAVA_1_16)
 					format = JAVA_1_16;

--- a/CppProject/World/Section.cpp
+++ b/CppProject/World/Section.cpp
@@ -275,34 +275,76 @@ namespace CppProject
 			BoolType waterlogged;
 		};
 		FastVector<PreviewPaletteEntry> blockStylePalette;
+		StringType propertiesName, idName;
+		bool emptyNames = false;
+
+		if (format >= Chunk::JAVA_26_3)
+		{
+			propertiesName = "properties";
+			idName = "id";
+			emptyNames = true;
+		}
+		else
+		{
+			propertiesName = "Properties";
+			idName = "Name";
+		}
 
 		if (nbt->HasKey(paletteName))
 		{
-			QVector<NbtCompound*> paletteComp = nbt->List<TAG_COMPOUND, NbtCompound>(paletteName);
-			blockStylePalette.Alloc(paletteComp.size());
-			for (NbtCompound* entry : paletteComp)
+			auto parsePaletteEntry = [&](StringType id, NbtCompound* entry = nullptr)
 			{
-				// Parse ID
-				StringType id = entry->String("Name");
-				if (id != "air") // Non air
-				{
-					// Check waterlogged status
-					BoolType waterlogged = false;
-					if (entry->HasKey("Properties"))
-					{
-						NbtCompound* props = entry->Compound("Properties");
-						if (props->HasKey("waterlogged") && !World::waterRemoved) // Waterlogged status
-							waterlogged = (props->String("waterlogged") == "true");
-					}
-
-					preview.hasBlocks = true;
-					blockStylePalette.Append({
-						Preview::filteredMcBlockIdStyleIndexMap.value(id),
-						(waterlogged || World::filteredMcBlockIdWaterloggedMap.value(id, false))
-					});
-				}
-				else
+				if (id == "air") { // Air blocks
 					blockStylePalette.Append({ 0, false });
+					return;
+				}
+
+				// Check waterlogged status
+				BoolType waterlogged = false;
+				if (entry && entry->HasKey(propertiesName))
+				{
+					NbtCompound* props = entry->Compound(propertiesName);
+					if (props->HasKey("waterlogged") && !World::waterRemoved) // Waterlogged status
+						waterlogged = (props->String("waterlogged") == "true");
+				}
+
+				preview.hasBlocks = true;
+				blockStylePalette.Append({
+					Preview::filteredMcBlockIdStyleIndexMap.value(id),
+					(waterlogged || World::filteredMcBlockIdWaterloggedMap.value(id, false))
+				});
+			};
+
+			NbtTag* paletteTag = nbt->value.value(paletteName);
+			if (paletteTag->type != TAG_LIST) {
+				WARNING("Invalid section: Unexpected Palette tag type");
+				return;
+			}
+
+			NbtType paletteType = ((NbtList*)paletteTag)->listType;
+			if (paletteType != TAG_COMPOUND && paletteType != TAG_STRING) {
+				WARNING("Invalid section: Unexpected Palette tag list type");
+				return;
+			}
+
+			// List of compounds
+			if (paletteType == TAG_COMPOUND)
+			{
+				QVector<NbtCompound*> paletteComps = nbt->List<TAG_COMPOUND, NbtCompound>(paletteName);
+				for (NbtCompound* entry : paletteComps)
+				{
+					if (entry->HasKey(idName))
+						parsePaletteEntry(entry->String(idName), entry);
+					else if (emptyNames && entry->HasKey(""))
+						parsePaletteEntry(entry->String(""), entry);
+				}
+			}
+			// List of strings
+			else
+			{
+				QVector<NbtString*> paletteStrings = nbt->List<TAG_STRING, NbtString>(paletteName);
+				for (NbtString* entry : paletteStrings)
+					parsePaletteEntry(entry->value);
 			}
 		}
 
@@ -394,15 +436,26 @@ namespace CppProject
 	void Section::ParseBlockPaletteBuilder(NbtCompound* nbt, StringType paletteName, StringType dataName, Chunk::Format format)
 	{
 		QVector<BoolType> paletteHasTimeline;
+		StringType propertiesName, idName;
+		bool emptyNames = false;
+		
+		if (format >= Chunk::JAVA_26_3)
+		{
+			propertiesName = "properties";
+			idName = "id";
+			emptyNames = true;
+		}
+		else
+		{
+			propertiesName = "Properties";
+			idName = "Name";
+		}
 
+		// Convert NBT palette into builder palette
 		if (nbt->HasKey(paletteName))
 		{
-			// Convert NBT palette into builder palette
-			QVector<NbtCompound*> paletteComp = nbt->List<TAG_COMPOUND, NbtCompound>(paletteName);
-			builder.palette.Alloc(paletteComp.size());
-			for (NbtCompound* entry : paletteComp)
+			auto parsePaletteEntry = [&](StringType id, NbtCompound* entry = nullptr)
 			{
-				StringType id = entry->String("Name");
 				if (id != "air") // Non air
 				{
 					if (obj_block* block = Builder::filteredMcBlockIdObjMap.value(id, nullptr))
@@ -410,9 +463,9 @@ namespace CppProject
 						BuilderState state = { (uint16_t)block->block_id, 0, World::filteredMcBlockIdWaterloggedMap.value(id, false) };
 						ArrType vars = Builder::mcBlockIdStateVarsMap.value(id, ArrType());
 
-						if (entry->HasKey("Properties")) // Parse properties
+						if (entry && entry->HasKey(propertiesName)) // Parse properties
 						{
-							NbtCompound* propertiesComp = entry->Compound("Properties");
+							NbtCompound* propertiesComp = entry->Compound(propertiesName);
 							QHashIterator<StringType, NbtTag*> propIt(propertiesComp->value);
 							while (propIt.hasNext())
 							{
@@ -440,13 +493,46 @@ namespace CppProject
 
 						builder.palette.Append(state);
 						paletteHasTimeline.append(block->timeline);
-						continue;
+						return;
 					}
 				}
 
-				// Air
 				builder.palette.Append({ 0, 0, false });
 				paletteHasTimeline.append(false);
+			};
+
+			NbtTag* paletteTag = nbt->value.value(paletteName);
+			if (paletteTag->type != TAG_LIST) {
+				WARNING("Invalid section: Unexpected Palette tag type");
+				return;
+			}
+
+			NbtType paletteType = ((NbtList*)paletteTag)->listType;
+			if (paletteType != TAG_COMPOUND && paletteType != TAG_STRING) {
+				WARNING("Invalid section: Unexpected Palette tag list type");
+				return;
+			}
+			
+			// List of compounds
+			if (paletteType == TAG_COMPOUND)
+			{
+				QVector<NbtCompound*> paletteComps = nbt->List<TAG_COMPOUND, NbtCompound>(paletteName);
+				builder.palette.Alloc(paletteComps.size());
+				for (NbtCompound* entry : paletteComps)
+				{
+					if (entry->HasKey(idName))
+						parsePaletteEntry(entry->String(idName), entry);
+					else if (emptyNames && entry->HasKey(""))
+						parsePaletteEntry(entry->String(""), entry);
+				}
+			}
+			// List of strings
+			else
+			{
+				QVector<NbtString*> paletteStrings = nbt->List<TAG_STRING, NbtString>(paletteName);
+				builder.palette.Alloc(paletteStrings.size());
+				for (NbtString* entry : paletteStrings)
+					parsePaletteEntry(entry->value);
 			}
 		}
 

--- a/CppProject/World/World.hpp
+++ b/CppProject/World/World.hpp
@@ -481,7 +481,8 @@ namespace CppProject
 			JAVA_1_2, // Anvil format, sections with byte arrays
 			JAVA_1_13 = 1451, // The flattening, palettes in sections
 			JAVA_1_16 = 2529, // Long array index bits snapped to 64
-			JAVA_1_18 = 2838 // Lowercase keys in sections
+			JAVA_1_18 = 2838, // Lowercase keys in sections
+			JAVA_26_3 = 5009 // Palette string lists, empty names, lowercase properties
 		};
 
 		// Face direction

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2026 David Andrei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
   <img src="https://www.mineimatorforums.com/uploads/monthly_2023_03/336815532_programview.png.9212aa1f6d1bed63411408aa5e905ce0.png" width=800/>
 </p>
 
-Mine-imator is a 3D movie maker based on the sandbox game Minecraft, with over 8 million downloads since its launch in 2012. Version 2.0, the 10th anniversary update brings numerous additions including a new UI, new renderer, animation features, multiplatform support and 3D world importer.
+Mine-imator is a 3D movie maker based on the sandbox game Minecraft, with over 10 million downloads since its launch in 2012. Version 2.0, the 10th anniversary update brings numerous additions including a new UI, new renderer, animation features, multiplatform support and 3D world importer.
 
 Website and download: https://www.mineimator.com
 
 The software is written using GameMaker Language and converted to a separate C++ environment using a custom built GML parser (CppGen). The final executable is built for Windows, Mac OS and Linux using the Qt framework, DirectX/OpenGL rendering and various other libraries.
+
+You can open GmProject/Mine-imator.yyp directly in GameMaker on Windows (it may need to be converted), but to support all features you must build and run the C++ project. For full build instructions, see CppProject/BUILD.md.


### PR DESCRIPTION
.NET 9 did in fact speed the compiling process so this is mostly just one of those simple changes, it is nothing major so it doesn't affect anything else to mine-imator besides the compiling from GML to C++.

Also it does remove all warnings mentioning .NET 6 being outdated.

Honestly this is my worst contribution, it's too simple. ToT