### PR TITLE
Support Sponge Schematic version 2 and 3 (.schem)

### DIFF
--- a/GmProject/scripts/asset_load/asset_load.gml
+++ b/GmProject/scripts/asset_load/asset_load.gml
@@ -78,6 +78,7 @@ function asset_load()
 			return true
 		
 		case ".schematic":
+		case ".schem":
 		case ".nbt":
 		case ".blocks":
 			log("Opening scenery", fn)

--- a/GmProject/scripts/builder_read_file/builder_read_file.gml
+++ b/GmProject/scripts/builder_read_file/builder_read_file.gml
@@ -65,6 +65,7 @@ function builder_read_schematic(map)
 			sch_palette_waterlogged[i] = false
 		}
 		
+		var palettemax = 0;
 		var key = ds_map_find_first(palettemap);
 		while (!is_undefined(key))
 		{
@@ -73,6 +74,9 @@ function builder_read_schematic(map)
 				var index, bracketindex;
 				index = palettemap[?key]
 				bracketindex = string_pos("[", key)
+				
+				if (index + 1 > palettemax)
+					palettemax = index + 1
 					
 				// Has properties
 				if (bracketindex > 0)
@@ -130,6 +134,59 @@ function builder_read_schematic(map)
 		
 		sch_blockdata_ints = (map[?"BlockData_NBT_type"] = e_nbt.TAG_INT_ARRAY)
 		debug("blockdataints", sch_blockdata_ints)
+		
+		// BlockData is an array of varints (Sponge Schematic specification). An index below 128
+		// encodes as a single byte and can be read from the file buffer directly, anything above
+		// spans several bytes. The block loop needs random access into the array, so decode the
+		// indices once into big endian integers appended to the file buffer.
+		if (!sch_blockdata_ints && palettemax > 128)
+		{
+			var blockamount, basepos, readpos, endpos, writepos;
+			blockamount = build_size_x * build_size_y * build_size_z
+			basepos = buffer_get_size(buffer_current)
+			readpos = sch_blockdata_array
+			endpos = sch_blockdata_array + map[?"BlockData_NBT_length"]
+			writepos = basepos
+			
+			// Missing entries are left at zero, so a truncated array still loads
+			buffer_resize(buffer_current, basepos + blockamount * 4)
+			
+			for (var i = 0; i < blockamount; i++)
+			{
+				var value, mul, byte;
+				value = 0
+				mul = 1
+				byte = 128
+				
+				while (byte >= 128)
+				{
+					if (readpos >= endpos)
+					{
+						log("Schematic warning", "BlockData ends before the last block")
+						break
+					}
+					
+					byte = buffer_peek(buffer_current, readpos, buffer_u8)
+					readpos++
+					value += (byte mod 128) * mul
+					mul *= 128
+				}
+				
+				if (readpos >= endpos && byte >= 128)
+					break
+				
+				// Store as a big endian integer, matching the TAG_Int_Array layout
+				buffer_poke(buffer_current, writepos, buffer_u8, (value div 16777216) mod 256)
+				buffer_poke(buffer_current, writepos + 1, buffer_u8, (value div 65536) mod 256)
+				buffer_poke(buffer_current, writepos + 2, buffer_u8, (value div 256) mod 256)
+				buffer_poke(buffer_current, writepos + 3, buffer_u8, value mod 256)
+				writepos += 4
+			}
+			
+			log("Decoded varint BlockData", blockamount)
+			sch_blockdata_array = basepos
+			sch_blockdata_ints = true
+		}
 		
 		// Get map
 		var metadata = map[?"Metadata"]

--- a/GmProject/scripts/builder_read_file/builder_read_file.gml
+++ b/GmProject/scripts/builder_read_file/builder_read_file.gml
@@ -7,8 +7,11 @@ function builder_read_schematic(map)
 		return false
 	}
 	
-	// Get format
-	builder_scenery_legacy = is_undefined(map[?"Palette"])
+	// Get format, version 3 keeps the palette inside a Blocks compound while a legacy
+	// schematic stores a Blocks byte array, so compare the tag type instead of the value
+	builder_scenery_legacy = is_undefined(map[?"Palette"]) && (map[?"Blocks_NBT_type"] != e_nbt.TAG_COMPOUND)
+	
+	var blocksmap = map;
 	
 	// Get size
 	build_size_x = map[?"Width"]
@@ -43,14 +46,25 @@ function builder_read_schematic(map)
 		}
 		
 		log("Version", map[?"Version"])
-		if (version > 1)
+		if (version > 3)
 		{
 			log("Schematic error", "Unsupported format, version too high")
 			return false
 		}
 		
+		// Version 3 moved the palette, block data and block entities into a Blocks compound
+		if (version >= 3)
+		{
+			blocksmap = map[?"Blocks"]
+			if (!ds_map_valid(blocksmap))
+			{
+				log("Schematic error", "Blocks compound not found")
+				return false
+			}
+		}
+		
 		// Get palette
-		var palettemap = map[?"Palette"]
+		var palettemap = blocksmap[?"Palette"]
 		if (!ds_map_valid(palettemap))
 		{
 			log("Schematic error", "Palette not found")
@@ -124,15 +138,16 @@ function builder_read_schematic(map)
 			key = ds_map_find_next(palettemap, key)
 		}
 		
-		// Get block array
-		sch_blockdata_array = map[?"BlockData"]
+		// Get block array, version 3 renamed BlockData to Blocks.Data
+		var blockdatakey = (version >= 3 ? "Data" : "BlockData");
+		sch_blockdata_array = blocksmap[?blockdatakey]
 		if (is_undefined(sch_blockdata_array))
 		{
-			log("Schematic error", "BlockData array not found")
+			log("Schematic error", "Block data array not found")
 			return false
 		}
 		
-		sch_blockdata_ints = (map[?"BlockData_NBT_type"] = e_nbt.TAG_INT_ARRAY)
+		sch_blockdata_ints = (blocksmap[?blockdatakey + "_NBT_type"] = e_nbt.TAG_INT_ARRAY)
 		debug("blockdataints", sch_blockdata_ints)
 		
 		// BlockData is an array of varints (Sponge Schematic specification). An index below 128
@@ -145,7 +160,7 @@ function builder_read_schematic(map)
 			blockamount = build_size_x * build_size_y * build_size_z
 			basepos = buffer_get_size(buffer_current)
 			readpos = sch_blockdata_array
-			endpos = sch_blockdata_array + map[?"BlockData_NBT_length"]
+			endpos = sch_blockdata_array + blocksmap[?blockdatakey + "_NBT_length"]
 			writepos = basepos
 			
 			// Missing entries are left at zero, so a truncated array still loads
@@ -217,7 +232,12 @@ function builder_read_schematic(map)
 	if (is_undefined(file_map))
 		file_map = ""
 		
+	// Version 2 renamed TileEntities to BlockEntities, version 3 moved it into Blocks
 	sch_tileentity_list = map[?"TileEntities"];
+	if (!ds_list_valid(sch_tileentity_list))
+		sch_tileentity_list = map[?"BlockEntities"]
+	if (!ds_list_valid(sch_tileentity_list))
+		sch_tileentity_list = blocksmap[?"BlockEntities"]
 	
 	return true
 }

--- a/GmProject/scripts/file_dialog_open_scenery/file_dialog_open_scenery.gml
+++ b/GmProject/scripts/file_dialog_open_scenery/file_dialog_open_scenery.gml
@@ -2,5 +2,5 @@
 
 function file_dialog_open_scenery()
 {
-	return file_dialog_open(text_get("filedialogopenscenery") + " (*.schematic; *.nbt; *.blocks)|*.schematic;*.nbt;*.blocks", "", schematics_directory, text_get("filedialogopenscenerycaption"))
+	return file_dialog_open(text_get("filedialogopenscenery") + " (*.schematic; *.schem; *.nbt; *.blocks)|*.schematic;*.schem;*.nbt;*.blocks", "", schematics_directory, text_get("filedialogopenscenerycaption"))
 }

--- a/GmProject/scripts/macros/macros.gml
+++ b/GmProject/scripts/macros/macros.gml
@@ -58,7 +58,7 @@ function macros()
 	#macro unzip_directory				file_directory + "unzip/"
 	#macro render_default				"performance"
 	#macro render_default_file			render_directory + render_default + ".mirender"
-	#macro asset_exts					"*.miobject;*.miframes;*.zip;*.schematic;*.miproject;*.miparticles;*.mimodel;*.png;*.jpg;*.json;*.ttf;*.mp3;*.wav;*.ogg;*.flac;*.wma;*.m4a;*.object;*.keyframes;*.particles;*.mproj;*.mani;*.blocks;*.nbt;*.dat;"
+	#macro asset_exts					"*.miobject;*.miframes;*.zip;*.schematic;*.schem;*.miproject;*.miparticles;*.mimodel;*.png;*.jpg;*.json;*.ttf;*.mp3;*.wav;*.ogg;*.flac;*.wma;*.m4a;*.object;*.keyframes;*.particles;*.mproj;*.mani;*.blocks;*.nbt;*.dat;"
 	
 	// Minecraft structure
 	#macro mc_file_directory			file_directory + "Minecraft_unzip/"

--- a/GmProject/scripts/res_load_scenery/res_load_scenery.gml
+++ b/GmProject/scripts/res_load_scenery/res_load_scenery.gml
@@ -38,7 +38,7 @@ function res_load_scenery()
 		
 				// Schematic/Structure file
 				var ext = filename_ext(fname);
-				if (ext = ".schematic" || ext = ".nbt")
+				if (ext = ".schematic" || ext = ".schem" || ext = ".nbt")
 				{
 					log("Loading " + ext, fname)
 					debug_timer_start()
@@ -67,11 +67,20 @@ function res_load_scenery()
 						nbt_debug_tag_compound("root", rootmap)
 					
 					// Parse blocks
-					if (ext == ".schematic")
+					if (ext == ".schematic" || ext == ".schem")
 					{
+						// Version 3 nests the schematic inside the unnamed root compound
+						var schematicmap = rootmap[?"Schematic"];
+						if (!ds_map_valid(schematicmap))
+						{
+							var unnamedmap = rootmap[?""];
+							if (ds_map_valid(unnamedmap))
+								schematicmap = unnamedmap[?"Schematic"]
+						}
+						
 						with (mc_builder)
 						{
-							openerr = !builder_read_schematic(rootmap[?"Schematic"])
+							openerr = !builder_read_schematic(schematicmap)
 							if (openerr)
 								break;
 						


### PR DESCRIPTION
Builds on #41, which this branch contains as its first commit.

### Problem

`builder_read_schematic` rejects any schematic whose `Version` tag is above 1:

```gml
if (version > 1)
{
    log("Schematic error", "Unsupported format, version too high")
    return false
}
```

WorldEdit and the other current tools write [version 2](https://github.com/SpongePowered/Schematic-Specification/blob/master/versions/schematic-2.md) and [version 3](https://github.com/SpongePowered/Schematic-Specification/blob/master/versions/schematic-3.md) files with a `.schem` extension, so they cannot be opened at all — and `.schem` is not in the scenery file dialog, `asset_load` or `asset_exts` either.

### Format differences handled

| | version 1 | version 2 | version 3 |
|---|---|---|---|
| root compound | `Schematic` | `Schematic` | `""` → `Schematic` |
| palette | `Palette` | `Palette` | `Blocks.Palette` |
| block indices | `BlockData` | `BlockData` | `Blocks.Data` |
| block entities | `TileEntities` | `BlockEntities` | `Blocks.BlockEntities` |

Block entity objects carry `Id` and `Pos` in all three versions, so `builder_read_schematic_tile_entities` works unchanged once the right list is picked up.

### Change

* `builder_read_schematic` resolves the palette, block data and block entity list per version.
* `res_load_scenery` unwraps the version 3 root compound.
* The format check compares the *tag type* of `Blocks` rather than its value, so a version 3 `Blocks` compound is recognised while a legacy MCEdit `Blocks` byte array still takes the legacy path.
* `.schem` added to the scenery file dialog, `asset_load` and `asset_exts`.

### Verification

* The new GML was transliterated line for line and run against real gzipped NBT files: versions 1, 2 and 3 with palettes of 64, 300 and 4096 entries all decode with zero mismatches and resolve the correct block entity list, and a legacy MCEdit schematic is still detected as legacy. A deliberate mutation of the decode loop was caught.
* `CppGen` was run over `GmProject` and reports `Success!`.
* As with the parent PR I could not build and run the application, so this has not been exercised through the UI.

`CppProject/Generated` is left untouched and needs a CppGen run to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
