### PR TITLE
C++ FPS/frame-scheduling fix

### DIFF
--- a/CppProject/AppHandler.cpp
+++ b/CppProject/AppHandler.cpp
@@ -251,7 +251,8 @@ namespace CppProject
 		fpsSampleStart = std::chrono::steady_clock::now();
 		fpsSampleFrames = 0;
 		gmlGlobal::fps = 0;
-		stepTimer.start(10, this);
+		stepDeadline = fpsSampleStart + std::chrono::milliseconds(10);
+		stepTimer.start(10, Qt::PreciseTimer, this);
 	}
 
 	AppWindow* AppHandler::AddWindow(QRect rect, IntType id, AppWindow* from)
@@ -286,6 +287,7 @@ namespace CppProject
 	void AppHandler::timerEvent(QTimerEvent* event)
 	{
 		stepTimer.stop();
+		auto stepStart = std::chrono::steady_clock::now();
 
 		// Debug
 		if (keyboard_check_pressed(vk_f6) && dev_mode)
@@ -413,8 +415,8 @@ namespace CppProject
 			// Calculate delta_time as duration of previous step in microseconds
 			gmlGlobal::delta_time = fpsTimer.ElapsedMs() * 1000.0;
 
-			// Calculate fps using duration of previous step minus step timer delay
-			double elapsedMs = fpsTimer.ElapsedMs() - 1000.0 / targetFps;
+			// Measure processing time directly, excluding the variable timer delay
+			double elapsedMs = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - stepStart).count();
 			if (elapsedMs > 0.0)
 				gmlGlobal::fps_real = 1.0 / (elapsedMs / 1000.0);
 
@@ -433,9 +435,15 @@ namespace CppProject
 		// Delete finished sounds
 		SoundInstance::CleanSounds();
 
-		// Schedule next step
+		// Wait only for the remaining frame budget, preserving fractional milliseconds
+		auto stepNow = std::chrono::steady_clock::now();
+		auto stepBudget = std::chrono::duration<double>(1.0 / std::max(IntType(1), targetFps));
+		stepDeadline += std::chrono::duration_cast<std::chrono::steady_clock::duration>(stepBudget);
+		if (stepDeadline < stepNow)
+			stepDeadline = stepNow; // Do not accumulate catch-up frames after a slow frame or dialog
+		auto stepDelay = std::chrono::ceil<std::chrono::milliseconds>(stepDeadline - stepNow);
 		fpsTimer.Reset();
-		stepTimer.start(1000.0 / targetFps, this);
+		stepTimer.start(int(stepDelay.count()), Qt::PreciseTimer, this);
 	}
 
 	IntType AppHandler::GetMsec() const

--- a/CppProject/AppHandler.cpp
+++ b/CppProject/AppHandler.cpp
@@ -248,6 +248,9 @@ namespace CppProject
 		DEBUG("Resources loaded");
 
 		// Start application loop
+		fpsSampleStart = std::chrono::steady_clock::now();
+		fpsSampleFrames = 0;
+		gmlGlobal::fps = 0;
 		stepTimer.start(10, this);
 	}
 
@@ -393,6 +396,17 @@ namespace CppProject
 			addedWindows.clear();
 		}
 
+		// Measure completed frames
+		auto fpsNow = std::chrono::steady_clock::now();
+		fpsSampleFrames++;
+		double fpsElapsed = std::chrono::duration<double>(fpsNow - fpsSampleStart).count();
+		if (fpsElapsed >= 1.0)
+		{
+			gmlGlobal::fps = std::clamp(IntType(fpsSampleFrames / fpsElapsed + 0.5), IntType(0), targetFps);
+			fpsSampleFrames = 0;
+			fpsSampleStart = fpsNow;
+		}
+
 		// Update fps every second
 		if (fpsLastUpdate.msecsTo(QDateTime::currentDateTime()) > 1000)
 		{
@@ -404,7 +418,6 @@ namespace CppProject
 			if (elapsedMs > 0.0)
 				gmlGlobal::fps_real = 1.0 / (elapsedMs / 1000.0);
 
-			gmlGlobal::fps = std::clamp(gmlGlobal::fps_real, IntType(0), targetFps);
 			fpsLastUpdate = QDateTime::currentDateTime();
 
 			// Clean unused data

--- a/CppProject/AppHandler.hpp
+++ b/CppProject/AppHandler.hpp
@@ -80,6 +80,7 @@ namespace CppProject
 		QVector<AddedWindow> addedWindows;
 
 		QBasicTimer stepTimer;
+		std::chrono::steady_clock::time_point stepDeadline;
 		BoolType blocked = false;
 
 		Timer randomizeTimer;

--- a/CppProject/AppHandler.hpp
+++ b/CppProject/AppHandler.hpp
@@ -88,6 +88,8 @@ namespace CppProject
 		IntType targetFps = 60;
 		Timer fpsTimer;
 		QDateTime fpsLastUpdate;
+		std::chrono::steady_clock::time_point fpsSampleStart;
+		IntType fpsSampleFrames = 0;
 
 		QNetworkAccessManager httpManager;
 		IntType httpNextId = 1;

--- a/GmProject/scripts/app_update_mouse/app_update_mouse.gml
+++ b/GmProject/scripts/app_update_mouse/app_update_mouse.gml
@@ -55,7 +55,7 @@ function app_update_mouse()
 	
 	if (mouse_click_count = 1)
 	{
-		mouse_click_timer += (1/fps) * 1000
+		mouse_click_timer += (1/max(1, fps)) * 1000
 		
 		if (mouse_click_timer < 500 && mouse_left_pressed)
 			mouse_click_count++


### PR DESCRIPTION
The C++ side of the app reports fps incorrectly and adds an unnecessary delay between frames. Using an external profiler like [PresentMon](https://github.com/GameTechDev/PresentMon) shows FPS mis-match with what's displayed in-app.

Made the following fixes:

- `fps` now measures completed frames over elapsed time, capped at the target FPS.
- `fps_real` now measures frame-processing time directly, excluding the scheduler’s wait.
- The scheduler now only waits for the remaining frame budget. (ie. previously a 60 FPS target added ~16ms of wait, giving 58-59fps instead.)
- Mouse click fix for 0 fps.

Opening this PR for discussion in case there's any behavior I'm not aware of that relies on previous fps/frame-scheduling logic.